### PR TITLE
Add explicit license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "type": "git",
     "url": "https://github.com/davehorton/node-esl.git"
   },
+  "license": "MPL-2.0",
   "main": "lib/index",
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION
This matches the MPL 2.0 license in the repo.